### PR TITLE
#39 tagsorting complete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'rails-observers'
 
 group :development, :test do
   gem 'coveralls', require: false
+  gem 'orderly'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    orderly (0.0.2)
     pg (0.18.2)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -209,6 +210,7 @@ DEPENDENCIES
   coveralls
   jbuilder (~> 2.0)
   jquery-rails
+  orderly
   pg
   rails (= 4.2.3)
   rails-observers
@@ -222,4 +224,4 @@ DEPENDENCIES
   yt (~> 0.13.7)
 
 BUNDLED WITH
-   1.10.4
+   1.10.5

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,8 +1,8 @@
 class VideosController < ApplicationController
 
   def index
-    @tags = Tag.all
-    
+    @tags = Tag.top(5)
+
   end
 
   def new

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,14 @@
 class Tag < ActiveRecord::Base
   has_many :taggings
   has_many :videos, through: :taggings
+
+
+  scope :top, ->(num_results = 5) {
+    select("tags.id, tags.name, count(taggings.id) AS taggings_count").
+    joins(:taggings).
+    group("tags.id").
+    order("taggings_count DESC").
+    limit(num_results)
+  }
+
 end

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -74,4 +74,16 @@ feature 'Videos' do
   #
   # end
 
+  scenario 'shows tags by popularity: tag with three videos, then two, then one' do
+    add_video('https://www.youtube.com/watch?v=riZck9O-kBU','test1')
+    add_video('https://www.youtube.com/watch?v=CAA_zE5a3JQ','test2')
+    add_video('https://www.youtube.com/watch?v=gcgt2aRFdt0','test3')
+    add_video('https://www.youtube.com/watch?v=VBmCJEehYtU','test2')
+    add_video('https://www.youtube.com/watch?v=fWNaR-rxAic','test3')
+    add_video('https://www.youtube.com/watch?v=uPMHzPBrZeI','test3')
+    visit '/'
+    expect('test3').to appear_before('test2')
+    expect('test2').to appear_before('test1')
+  end
+
 end


### PR DESCRIPTION
Creates a top() scope for the Tag class that returns tags sorted by the number of videos in each, which is then used to sort tags on the homepage into popularity order. Fully test-driven. The scope makes a select call across two db tables each time. There's another more scalable approach outlined at http://stackoverflow.com/questions/8696005/rails-3-activerecord-order-by-count-on-association that may become necessary if the database grows too big or becomes too popular.