### PR TITLE
closes #51 heroku deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,10 @@ gem 'rails-observers'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+group :production do
+  gem 'rails_12factor'
+end
+
 group :development, :test do
   gem 'coveralls', require: false
   gem 'orderly'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,11 @@ GEM
       loofah (~> 2.0)
     rails-observers (0.1.2)
       activemodel (~> 4.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.3)
     railties (4.2.3)
       actionpack (= 4.2.3)
       activesupport (= 4.2.3)
@@ -214,6 +219,7 @@ DEPENDENCIES
   pg
   rails (= 4.2.3)
   rails-observers
+  rails_12factor
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Couple of notes:

1) To push a non-master branch to the live Heroku site, I used `git push heroku 51-herokudeploy:master`
2) You'll need to run `heroku run rake db:migrate` after pushing across.
3) Heroku isn't attached to the master branch of our Github repo to automatically update at present, but I think that may be possible. Further instructions on deploying at https://devcenter.heroku.com/articles/git.